### PR TITLE
Fix uploading without a project #116 to develope!!

### DIFF
--- a/pros/cli/common.py
+++ b/pros/cli/common.py
@@ -158,9 +158,12 @@ def project_option(arg_name='project', required: bool = True, default: str = '.'
         import pros.conductor as c
         project_path = c.Project.find_project(value)
         if project_path is None:
-            raise click.UsageError(f'{os.path.abspath(value or ".")} is not inside a PROS project. '
-                                   f'Execute this command from within a PROS project or specify it '
-                                   f'with --project project/path')
+            if allow_none:
+                return None
+            else:
+                raise click.UsageError(f'{os.path.abspath(value or ".")} is not inside a PROS project. '
+                                       f'Execute this command from within a PROS project or specify it '
+                                       f'with --project project/path')
         return c.Project(project_path)
 
     def wrapper(f: Union[click.Command, Callable]):

--- a/pros/cli/upload.py
+++ b/pros/cli/upload.py
@@ -14,7 +14,7 @@ def upload_cli():
               help='Specify the target microcontroller. Overridden when a PROS project is specified.')
 @click.argument('path', type=click.Path(exists=True), default=None, required=False)
 @click.argument('port', type=str, default=None, required=False)
-@project_option(required=False)
+@project_option(required=False, allow_none=True)
 @click.option('--run-after/--no-run-after', 'run_after', default=True, help='Immediately run the uploaded program')
 @click.option('-q', '--quirk', type=int, default=0)
 @click.option('--name', 'remote_name', type=str, default=None, required=False, help='Remote program name',
@@ -66,7 +66,8 @@ def upload(path: Optional[str], project: Optional[c.Project], port: str, **kwarg
             kwargs['version'] = kwargs['program-version']
         if 'remote_name' not in kwargs:
             kwargs['remote_name'] = project.name
-    if 'target' not in kwargs:
+
+    if 'target' not in kwargs or kwargs['target'] is None:
         logger(__name__).debug(f'Target not specified. Arguments provided: {kwargs}')
         raise click.UsageError('Target not specified. specify a project (using the file argument) or target manually')
 


### PR DESCRIPTION
Summary:

Bubbled up a None project if we can't find it and say we don't need it. I also added some additional verification I noticed was needed to make sure a target was specified. I haven't had a chance to test this, so I might also need to do something with the .ini files in the upload layer.
Motivation:

A couple of people have mentioned wanting this, and it's convenient occasionally.
References (optional):

Fixes #96
Test Plan:

Uploading to a v5 still works with a project

    Uploading to a v5 works without a project

Open questions:

I don't see any sort of verification on the file we upload. Should we add some?

Reading more and talking about it, I don't think we should.